### PR TITLE
feat: 新增 LINE Bot + Google Sheet 冰箱庫存 Apps Script 專案

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -1,0 +1,436 @@
+/**
+ * LINE Bot + Google Sheet 冰箱庫存系統
+ *
+ * 重要：
+ * 1) 請先在 Script Properties 設定：
+ *    - LINE_CHANNEL_ACCESS_TOKEN
+ *    - LINE_CHANNEL_SECRET
+ *    - SPREADSHEET_ID
+ * 2) 執行 initializeSheets() 建立 Users/Items/Logs 分頁與表頭
+ */
+
+const SHEET_NAMES = {
+  USERS: 'Users',
+  ITEMS: 'Items',
+  LOGS: 'Logs',
+};
+
+const USER_HEADERS = [
+  'userId',
+  'displayName',
+  'defaultReminderDays',
+  'createdAt',
+  'updatedAt',
+];
+
+const ITEM_HEADERS = [
+  'itemId',
+  'userId',
+  'itemName',
+  'quantity',
+  'unit',
+  'expiryDate',
+  'createdAt',
+  'updatedAt',
+  'status',
+];
+
+const LOG_HEADERS = [
+  'logId',
+  'timestamp',
+  'userId',
+  'action',
+  'itemName',
+  'quantityChange',
+  'note',
+  'rawMessage',
+];
+
+function doGet() {
+  return HtmlService.createHtmlOutputFromFile('web/index')
+    .setTitle('冰箱庫存管理介面')
+    .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL);
+}
+
+function doPost(e) {
+  try {
+    const body = JSON.parse(e.postData.contents);
+    const signature = e.postData.headers['X-Line-Signature'] || e.postData.headers['x-line-signature'];
+    if (!verifyLineSignature_(e.postData.contents, signature)) {
+      return ContentService.createTextOutput('invalid signature').setMimeType(ContentService.MimeType.TEXT);
+    }
+
+    if (!body.events || !body.events.length) {
+      return ContentService.createTextOutput('ok').setMimeType(ContentService.MimeType.TEXT);
+    }
+
+    body.events.forEach((event) => {
+      if (event.type !== 'message' || event.message.type !== 'text') return;
+      const userId = event.source.userId;
+      const input = (event.message.text || '').trim();
+      const reply = handleCommand_(userId, input);
+      if (event.replyToken) {
+        replyLineMessage_(event.replyToken, reply);
+      }
+    });
+
+    return ContentService.createTextOutput('ok').setMimeType(ContentService.MimeType.TEXT);
+  } catch (err) {
+    console.error(err);
+    return ContentService.createTextOutput('error').setMimeType(ContentService.MimeType.TEXT);
+  }
+}
+
+function initializeSheets() {
+  const ss = getSpreadsheet_();
+  ensureSheet_(ss, SHEET_NAMES.USERS, USER_HEADERS);
+  ensureSheet_(ss, SHEET_NAMES.ITEMS, ITEM_HEADERS);
+  ensureSheet_(ss, SHEET_NAMES.LOGS, LOG_HEADERS);
+  return '初始化完成：Users / Items / Logs';
+}
+
+function handleCommand_(userId, text) {
+  upsertUser_(userId);
+
+  if (/^新增\s+/.test(text)) return addItemCommand_(userId, text);
+  if (/^取出\s+/.test(text)) return takeItemCommand_(userId, text);
+  if (text === '清單') return listItemsCommand_(userId);
+  if (/^快過期/.test(text)) return expiringItemsCommand_(userId, text);
+  if (/^設定提醒\s+/.test(text)) return setReminderCommand_(userId, text);
+  return [
+    '指令格式：',
+    '1) 新增 品名 數量 [單位] [YYYY-MM-DD]',
+    '   例：新增 牛奶 2 瓶 2026-02-20',
+    '2) 取出 品名 數量',
+    '   例：取出 牛奶 1',
+    '3) 清單',
+    '4) 快過期 [天數]',
+    '   例：快過期 3',
+    '5) 設定提醒 天數',
+    '   例：設定提醒 5',
+  ].join('\n');
+}
+
+function addItemCommand_(userId, text) {
+  const parts = text.split(/\s+/);
+  if (parts.length < 3) return '格式錯誤：新增 品名 數量 [單位] [YYYY-MM-DD]';
+
+  const itemName = parts[1];
+  const quantity = Number(parts[2]);
+  if (Number.isNaN(quantity) || quantity <= 0) return '數量需為正數。';
+
+  let unit = '個';
+  let expiryDate = '';
+
+  if (parts[3]) {
+    if (/^\d{4}-\d{2}-\d{2}$/.test(parts[3])) {
+      expiryDate = parts[3];
+    } else {
+      unit = parts[3];
+    }
+  }
+  if (parts[4]) {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(parts[4])) return '日期格式需為 YYYY-MM-DD';
+    expiryDate = parts[4];
+  }
+
+  const now = new Date();
+  const itemSheet = getSheet_(SHEET_NAMES.ITEMS);
+  const itemId = Utilities.getUuid();
+  itemSheet.appendRow([
+    itemId,
+    userId,
+    itemName,
+    quantity,
+    unit,
+    expiryDate,
+    now,
+    now,
+    'active',
+  ]);
+
+  addLog_(userId, 'ADD', itemName, quantity, `unit=${unit}, expiry=${expiryDate || 'N/A'}`, text);
+  return `已新增：${itemName} ${quantity}${unit}${expiryDate ? `（到期：${expiryDate}）` : ''}`;
+}
+
+function takeItemCommand_(userId, text) {
+  const parts = text.split(/\s+/);
+  if (parts.length < 3) return '格式錯誤：取出 品名 數量';
+
+  const itemName = parts[1];
+  const takeQty = Number(parts[2]);
+  if (Number.isNaN(takeQty) || takeQty <= 0) return '數量需為正數。';
+
+  const sheet = getSheet_(SHEET_NAMES.ITEMS);
+  const values = sheet.getDataRange().getValues();
+  let remain = takeQty;
+
+  for (let i = 1; i < values.length; i++) {
+    const row = values[i];
+    const rowUserId = row[1];
+    const rowItemName = row[2];
+    const rowQty = Number(row[3]);
+    const status = row[8];
+
+    if (rowUserId !== userId || rowItemName !== itemName || status !== 'active' || rowQty <= 0) continue;
+
+    if (rowQty > remain) {
+      sheet.getRange(i + 1, 4).setValue(rowQty - remain);
+      sheet.getRange(i + 1, 8).setValue(new Date());
+      remain = 0;
+      break;
+    } else {
+      remain -= rowQty;
+      sheet.getRange(i + 1, 4).setValue(0);
+      sheet.getRange(i + 1, 8).setValue(new Date());
+      sheet.getRange(i + 1, 9).setValue('empty');
+      if (remain === 0) break;
+    }
+  }
+
+  const taken = takeQty - remain;
+  if (taken <= 0) return `找不到可取出的 ${itemName}。`;
+
+  addLog_(userId, 'TAKE', itemName, -taken, '', text);
+  return remain > 0
+    ? `已取出 ${itemName} ${taken}，但庫存不足，尚缺 ${remain}。`
+    : `已取出 ${itemName} ${taken}。`;
+}
+
+function listItemsCommand_(userId) {
+  const sheet = getSheet_(SHEET_NAMES.ITEMS);
+  const values = sheet.getDataRange().getValues();
+  const map = {};
+
+  values.slice(1).forEach((row) => {
+    if (row[1] !== userId || row[8] !== 'active') return;
+    const key = `${row[2]}|${row[4]}`;
+    const qty = Number(row[3]) || 0;
+    if (!map[key]) {
+      map[key] = { name: row[2], unit: row[4], qty: 0 };
+    }
+    map[key].qty += qty;
+  });
+
+  const items = Object.values(map);
+  if (!items.length) return '目前沒有庫存。';
+
+  const lines = items
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map((i) => `- ${i.name}：${i.qty}${i.unit}`);
+
+  return ['目前庫存：', ...lines].join('\n');
+}
+
+function expiringItemsCommand_(userId, text) {
+  const user = getUser_(userId);
+  const defaultDays = user ? Number(user.defaultReminderDays || 3) : 3;
+  const customMatch = text.match(/^快過期\s+(\d+)$/);
+  const days = customMatch ? Number(customMatch[1]) : defaultDays;
+
+  const today = new Date();
+  const limit = new Date();
+  limit.setDate(today.getDate() + days);
+
+  const sheet = getSheet_(SHEET_NAMES.ITEMS);
+  const values = sheet.getDataRange().getValues();
+  const lines = [];
+
+  values.slice(1).forEach((row) => {
+    if (row[1] !== userId || row[8] !== 'active' || !row[5]) return;
+    const expiry = new Date(row[5]);
+    if (expiry >= startOfDay_(today) && expiry <= endOfDay_(limit)) {
+      const qty = Number(row[3]) || 0;
+      lines.push(`- ${row[2]}：${qty}${row[4]}（到期：${formatDate_(expiry)}）`);
+    }
+  });
+
+  if (!lines.length) return `${days} 天內沒有快過期品項。`;
+  return [`${days} 天內快過期：`, ...lines].join('\n');
+}
+
+function setReminderCommand_(userId, text) {
+  const match = text.match(/^設定提醒\s+(\d+)$/);
+  if (!match) return '格式錯誤：設定提醒 天數';
+
+  const days = Number(match[1]);
+  if (days < 1 || days > 365) return '提醒天數需介於 1~365。';
+
+  upsertUser_(userId, { defaultReminderDays: days });
+  addLog_(userId, 'SET_REMINDER', '', 0, `days=${days}`, text);
+  return `已設定預設快過期提醒為 ${days} 天。`;
+}
+
+function checkAndPushExpiryReminders() {
+  const userSheet = getSheet_(SHEET_NAMES.USERS);
+  const users = userSheet.getDataRange().getValues().slice(1);
+
+  users.forEach((row) => {
+    const userId = row[0];
+    const days = Number(row[2] || 3);
+    const message = expiringItemsCommand_(userId, `快過期 ${days}`);
+    if (!/沒有快過期/.test(message)) {
+      pushLineMessage_(userId, message);
+    }
+  });
+}
+
+function verifyLineSignature_(rawBody, signature) {
+  if (!signature) return false;
+  const secret = getRequiredProperty_('LINE_CHANNEL_SECRET');
+  const hash = Utilities.base64Encode(
+    Utilities.computeHmacSha256Signature(rawBody, secret),
+  );
+  return hash === signature;
+}
+
+function replyLineMessage_(replyToken, text) {
+  const token = getRequiredProperty_('LINE_CHANNEL_ACCESS_TOKEN');
+  const payload = {
+    replyToken,
+    messages: [{ type: 'text', text }],
+  };
+
+  UrlFetchApp.fetch('https://api.line.me/v2/bot/message/reply', {
+    method: 'post',
+    contentType: 'application/json',
+    headers: { Authorization: `Bearer ${token}` },
+    payload: JSON.stringify(payload),
+    muteHttpExceptions: true,
+  });
+}
+
+function pushLineMessage_(userId, text) {
+  const token = getRequiredProperty_('LINE_CHANNEL_ACCESS_TOKEN');
+  const payload = {
+    to: userId,
+    messages: [{ type: 'text', text }],
+  };
+
+  UrlFetchApp.fetch('https://api.line.me/v2/bot/message/push', {
+    method: 'post',
+    contentType: 'application/json',
+    headers: { Authorization: `Bearer ${token}` },
+    payload: JSON.stringify(payload),
+    muteHttpExceptions: true,
+  });
+}
+
+function upsertUser_(userId, options) {
+  const sheet = getSheet_(SHEET_NAMES.USERS);
+  const values = sheet.getDataRange().getValues();
+  const now = new Date();
+  const opts = options || {};
+
+  for (let i = 1; i < values.length; i++) {
+    if (values[i][0] === userId) {
+      if (opts.defaultReminderDays) sheet.getRange(i + 1, 3).setValue(opts.defaultReminderDays);
+      sheet.getRange(i + 1, 5).setValue(now);
+      return;
+    }
+  }
+
+  sheet.appendRow([
+    userId,
+    opts.displayName || '',
+    opts.defaultReminderDays || 3,
+    now,
+    now,
+  ]);
+}
+
+function getUser_(userId) {
+  const sheet = getSheet_(SHEET_NAMES.USERS);
+  const values = sheet.getDataRange().getValues();
+  for (let i = 1; i < values.length; i++) {
+    if (values[i][0] === userId) {
+      return {
+        userId: values[i][0],
+        displayName: values[i][1],
+        defaultReminderDays: values[i][2],
+      };
+    }
+  }
+  return null;
+}
+
+function addLog_(userId, action, itemName, quantityChange, note, rawMessage) {
+  const sheet = getSheet_(SHEET_NAMES.LOGS);
+  sheet.appendRow([
+    Utilities.getUuid(),
+    new Date(),
+    userId,
+    action,
+    itemName,
+    quantityChange,
+    note || '',
+    rawMessage || '',
+  ]);
+}
+
+function ensureSheet_(ss, name, headers) {
+  let sheet = ss.getSheetByName(name);
+  if (!sheet) sheet = ss.insertSheet(name);
+
+  const existing = sheet.getRange(1, 1, 1, headers.length).getValues()[0];
+  const needsHeader = headers.some((h, i) => existing[i] !== h);
+
+  if (needsHeader) {
+    sheet.clear();
+    sheet.getRange(1, 1, 1, headers.length).setValues([headers]);
+    sheet.setFrozenRows(1);
+    sheet.getRange(1, 1, 1, headers.length).setFontWeight('bold');
+  }
+}
+
+function getSpreadsheet_() {
+  const id = getRequiredProperty_('SPREADSHEET_ID');
+  return SpreadsheetApp.openById(id);
+}
+
+function getSheet_(name) {
+  const sheet = getSpreadsheet_().getSheetByName(name);
+  if (!sheet) throw new Error(`找不到分頁：${name}，請先執行 initializeSheets()`);
+  return sheet;
+}
+
+function getRequiredProperty_(key) {
+  const value = PropertiesService.getScriptProperties().getProperty(key);
+  if (!value) throw new Error(`缺少 Script Property: ${key}`);
+  return value;
+}
+
+function formatDate_(date) {
+  return Utilities.formatDate(date, Session.getScriptTimeZone(), 'yyyy-MM-dd');
+}
+
+function startOfDay_(date) {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate(), 0, 0, 0);
+}
+
+function endOfDay_(date) {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate(), 23, 59, 59);
+}
+
+/**
+ * ===== 管理介面（web/index.html）呼叫函式 =====
+ */
+function getSettings() {
+  const props = PropertiesService.getScriptProperties();
+  const id = props.getProperty('SPREADSHEET_ID') || '';
+  const token = props.getProperty('LINE_CHANNEL_ACCESS_TOKEN') || '';
+  const secret = props.getProperty('LINE_CHANNEL_SECRET') || '';
+  return {
+    spreadsheetId: id,
+    lineTokenSet: Boolean(token),
+    lineSecretSet: Boolean(secret),
+  };
+}
+
+function saveSettings(data) {
+  const props = PropertiesService.getScriptProperties();
+  if (data.spreadsheetId) props.setProperty('SPREADSHEET_ID', data.spreadsheetId.trim());
+  if (data.lineChannelAccessToken) props.setProperty('LINE_CHANNEL_ACCESS_TOKEN', data.lineChannelAccessToken.trim());
+  if (data.lineChannelSecret) props.setProperty('LINE_CHANNEL_SECRET', data.lineChannelSecret.trim());
+  return '設定已儲存';
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,87 @@
-# daily-ai-hub
+# LINE Bot + Google Sheet 冰箱庫存系統（中文）
+
+本專案提供一個 Google Apps Script 範本，讓 LINE Bot 透過 Google Sheet 管理冰箱庫存。
+
+## 功能
+
+- 新增：`新增 品名 數量 [單位] [YYYY-MM-DD]`
+- 取出：`取出 品名 數量`
+- 清單：`清單`
+- 快過期：`快過期 [天數]`
+- 設定提醒：`設定提醒 天數`
+- 資料儲存在 Google Sheet（`Users` / `Items` / `Logs`）
+
+## 專案檔案
+
+- `Code.gs`：LINE Webhook、指令解析、Sheet 操作、提醒推播
+- `appsscript.json`：Apps Script Manifest（時區、權限、Web App 設定）
+- `web/index.html`：管理介面（儲存 Properties、初始化 Sheets）
+
+## Script Properties（金鑰與設定）
+
+> 所有敏感資料都透過 `PropertiesService.getScriptProperties()` 儲存，不會硬編碼。
+
+需設定以下鍵值：
+
+- `LINE_CHANNEL_ACCESS_TOKEN`
+- `LINE_CHANNEL_SECRET`
+- `SPREADSHEET_ID`
+
+## Sheet 設計
+
+### Users
+
+- `userId`
+- `displayName`
+- `defaultReminderDays`
+- `createdAt`
+- `updatedAt`
+
+### Items
+
+- `itemId`
+- `userId`
+- `itemName`
+- `quantity`
+- `unit`
+- `expiryDate`
+- `createdAt`
+- `updatedAt`
+- `status`（`active` / `empty`）
+
+### Logs
+
+- `logId`
+- `timestamp`
+- `userId`
+- `action`
+- `itemName`
+- `quantityChange`
+- `note`
+- `rawMessage`
+
+> 可執行 `initializeSheets()` 自動建立/修正三個分頁與表頭。
+
+## 部署清單（Deployment Checklist）
+
+1. 建立 Google Sheet，複製 Spreadsheet ID。
+2. 建立 Apps Script 專案，放入本 repo 三個檔案。
+3. 在 Apps Script 介面「專案設定 > Script properties」或管理頁面填入：
+   - `LINE_CHANNEL_ACCESS_TOKEN`
+   - `LINE_CHANNEL_SECRET`
+   - `SPREADSHEET_ID`
+4. 執行 `initializeSheets()`（首次需授權）。
+5. 部署為 Web App：
+   - Execute as: `User deploying the app`
+   - Who has access: `Anyone`
+6. 取得 Web App URL，填入 LINE Developers Webhook URL。
+7. 在 LINE Developers 開啟 Webhook，測試訊息：
+   - `新增 牛奶 2 瓶 2026-02-20`
+   - `清單`
+   - `快過期 7`
+8. （選用）建立時間觸發器執行 `checkAndPushExpiryReminders()`，例如每日 09:00。
+
+## 注意事項
+
+- Apps Script `doPost(e)` 已驗證 `X-Line-Signature`。
+- 若更換 Spreadsheet，請更新 `SPREADSHEET_ID` 後重跑 `initializeSheets()`。

--- a/appsscript.json
+++ b/appsscript.json
@@ -1,0 +1,15 @@
+{
+  "timeZone": "Asia/Taipei",
+  "exceptionLogging": "STACKDRIVER",
+  "runtimeVersion": "V8",
+  "webapp": {
+    "access": "ANYONE",
+    "executeAs": "USER_DEPLOYING"
+  },
+  "oauthScopes": [
+    "https://www.googleapis.com/auth/script.external_request",
+    "https://www.googleapis.com/auth/spreadsheets",
+    "https://www.googleapis.com/auth/script.scriptapp",
+    "https://www.googleapis.com/auth/userinfo.email"
+  ]
+}

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>冰箱庫存系統管理介面</title>
+    <style>
+      body {
+        font-family: "Noto Sans TC", Arial, sans-serif;
+        background: #f5f7fb;
+        margin: 0;
+        padding: 24px;
+      }
+      .card {
+        max-width: 720px;
+        background: #fff;
+        border-radius: 10px;
+        padding: 24px;
+        margin: 0 auto;
+        box-shadow: 0 4px 18px rgba(0, 0, 0, 0.08);
+      }
+      h1 {
+        margin-top: 0;
+        font-size: 22px;
+      }
+      .desc {
+        color: #666;
+        margin-bottom: 18px;
+      }
+      label {
+        display: block;
+        font-weight: bold;
+        margin-top: 14px;
+      }
+      input {
+        width: 100%;
+        box-sizing: border-box;
+        padding: 10px;
+        border: 1px solid #d4d7dd;
+        border-radius: 8px;
+        margin-top: 6px;
+      }
+      .hint {
+        color: #7a7a7a;
+        font-size: 13px;
+      }
+      button {
+        margin-top: 16px;
+        border: none;
+        border-radius: 8px;
+        padding: 10px 16px;
+        cursor: pointer;
+        font-weight: bold;
+      }
+      .btn-primary {
+        background: #1a73e8;
+        color: #fff;
+      }
+      .btn-secondary {
+        background: #34a853;
+        color: #fff;
+        margin-left: 8px;
+      }
+      .status {
+        margin-top: 16px;
+        padding: 10px;
+        border-radius: 8px;
+        display: none;
+      }
+      .ok {
+        background: #e8f5e9;
+        color: #1b5e20;
+      }
+      .err {
+        background: #ffebee;
+        color: #b71c1c;
+      }
+      ul {
+        margin-top: 8px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="card">
+      <h1>LINE Bot 冰箱庫存系統</h1>
+      <p class="desc">請在此設定 Script Properties，並初始化 Google Sheet 分頁與表頭。</p>
+
+      <label for="spreadsheetId">Spreadsheet ID</label>
+      <input id="spreadsheetId" placeholder="貼上 Google Sheet ID" />
+
+      <label for="lineToken">LINE Channel Access Token</label>
+      <input id="lineToken" type="password" placeholder="貼上 LINE access token" />
+
+      <label for="lineSecret">LINE Channel Secret</label>
+      <input id="lineSecret" type="password" placeholder="貼上 LINE channel secret" />
+
+      <p class="hint">安全性說明：金鑰儲存在 PropertiesService，不會硬編碼在程式碼中。</p>
+
+      <div>
+        <button class="btn-primary" onclick="saveSettings()">儲存設定</button>
+        <button class="btn-secondary" onclick="initializeSheets()">初始化 Sheets</button>
+      </div>
+
+      <div id="status" class="status"></div>
+
+      <h3>目前狀態</h3>
+      <ul>
+        <li id="stateSpreadsheet">Spreadsheet ID：讀取中...</li>
+        <li id="stateToken">LINE Token：讀取中...</li>
+        <li id="stateSecret">LINE Secret：讀取中...</li>
+      </ul>
+    </div>
+
+    <script>
+      function showStatus(message, ok) {
+        const el = document.getElementById('status');
+        el.style.display = 'block';
+        el.className = `status ${ok ? 'ok' : 'err'}`;
+        el.textContent = message;
+      }
+
+      function loadSettings() {
+        google.script.run
+          .withSuccessHandler((data) => {
+            document.getElementById('spreadsheetId').value = data.spreadsheetId || '';
+            document.getElementById('stateSpreadsheet').textContent =
+              `Spreadsheet ID：${data.spreadsheetId ? '已設定' : '未設定'}`;
+            document.getElementById('stateToken').textContent =
+              `LINE Token：${data.lineTokenSet ? '已設定' : '未設定'}`;
+            document.getElementById('stateSecret').textContent =
+              `LINE Secret：${data.lineSecretSet ? '已設定' : '未設定'}`;
+          })
+          .withFailureHandler((err) => showStatus(`讀取失敗：${err.message}`, false))
+          .getSettings();
+      }
+
+      function saveSettings() {
+        const payload = {
+          spreadsheetId: document.getElementById('spreadsheetId').value,
+          lineChannelAccessToken: document.getElementById('lineToken').value,
+          lineChannelSecret: document.getElementById('lineSecret').value,
+        };
+
+        google.script.run
+          .withSuccessHandler((msg) => {
+            showStatus(msg, true);
+            loadSettings();
+            document.getElementById('lineToken').value = '';
+            document.getElementById('lineSecret').value = '';
+          })
+          .withFailureHandler((err) => showStatus(`儲存失敗：${err.message}`, false))
+          .saveSettings(payload);
+      }
+
+      function initializeSheets() {
+        google.script.run
+          .withSuccessHandler((msg) => showStatus(msg, true))
+          .withFailureHandler((err) => showStatus(`初始化失敗：${err.message}`, false))
+          .initializeSheets();
+      }
+
+      loadSettings();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
### Motivation
- 提供一個可部署的 Google Apps Script 範本，讓 LINE Bot 能用 Google Sheet 管理冰箱庫存（中文介面與指令）。
- 功能包含：新增、取出、列清單、查詢快過期、設定提醒，且資料儲存在 Google Sheet（Users / Items / Logs）。
- 要求不將金鑰硬編碼，而是使用 `PropertiesService` 儲存 `LINE_CHANNEL_ACCESS_TOKEN` / `LINE_CHANNEL_SECRET` / `SPREADSHEET_ID`，並提供管理介面與初始化工具。

### Description
- 新增 `Code.gs`，包含 LINE webhook (`doPost`) 與簽章驗證、指令解析與處理（`新增`/`取出`/`清單`/`快過期`/`設定提醒`）、Sheet 操作、記錄 (`Logs`) 與 `checkAndPushExpiryReminders()` 可用於排程推播提醒。 
- 實作 `initializeSheets()` 與 `ensureSheet_()`，會自動建立或修正三個分頁 `Users` / `Items` / `Logs` 與對應表頭（包含欄位定義與凍結表頭）。
- 新增管理介面 `web/index.html`，提供透過 UI 儲存 Script Properties（不在程式內硬編碼金鑰）以及按鈕執行 `initializeSheets()`。 
- 新增 `appsscript.json`（時區、V8 runtime、Web App 設定與 OAuth scopes）與更新 `README.md`（功能說明、欄位設計、部署清單）。

### Testing
- 已驗證 `appsscript.json` 格式正確，執行 `python3 -m json.tool appsscript.json`（通過）。
- 嘗試以 `node --check` 檢查程式檔但失敗，原因是 Node 不支援 `.gs` 檔案副檔名，該檢查為非必要檢查且與 Apps Script 執行無關。 
- 嘗試用 Playwright 產生 `web/index.html` 截圖時，環境內 Chromium 啟動發生 SIGSEGV，導致截圖失敗；此問題屬於執行環境限制，不影響 Apps Script 檔案內容與功能實作。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69955397dba4832292b205d6fc1ca630)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit abae9677271e0e701b3606b1f690020496e731d0. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->